### PR TITLE
wpa_supplicant_lib: Fix the buffer length for SET_AP_P2P_WPS_IE ioctl

### DIFF
--- a/driver_cmd_nl80211.c
+++ b/driver_cmd_nl80211.c
@@ -178,7 +178,7 @@ int wpa_driver_set_ap_wps_p2p_ie(void *priv, const struct wpabuf *beacon,
 	for (i = 0; cmd_arr[i].cmd != -1; i++) {
 		ap_wps_p2p_ie = cmd_arr[i].src;
 		if (ap_wps_p2p_ie) {
-			buf_len = strlen(_cmd) + 3 + wpabuf_len(ap_wps_p2p_ie);
+			buf_len = strlen(_cmd) + 5 + wpabuf_len(ap_wps_p2p_ie);
 			buf = os_zalloc(buf_len);
 			if (NULL == buf) {
 				wpa_printf(MSG_ERROR, "%s: Out of memory",


### PR DESCRIPTION
With the buffer length of 3, the iftype argument was not included to the ioctl command. This resulted in wifi direct not working on
the Galaxy A21s.
With this fix included, ioctl works correctly and wifi direct was fixed.
Looking at the kernel sources of gta4xl and motorola_exynos9610 (which both use scsc wifi), I think this fix might work for them too (if their wifi direct was broken)